### PR TITLE
Update packages and move typescript into vsix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "version": "0.0.1",
     "publisher": "RIGANTI",
     "engines": {
-        "vscode": "^1.5.0"
+        "vscode": "^1.17.0"
     },
     "categories": [
         "Other"
@@ -15,42 +15,46 @@
     ],
     "main": "./extension",
     "contributes": {
-        "languages": [{
-            "id": "dotvvm",
-            "extensions": [
-                ".dothtml",
-                ".dotmaster",
-                ".dotcontrol"
-            ],
-            "configuration": "./language-configuration.json"
-        }],
-        "grammars": [{
-            "language": "dotvvm",
-            "scopeName": "text.html.dotvvm",
-            "path": "./syntaxes/dotvvm.tmLanguage.json",
-            "embeddedLanguages": {
-                "text.html": "html"
+        "languages": [
+            {
+                "id": "dotvvm",
+                "extensions": [
+                    ".dothtml",
+                    ".dotmaster",
+                    ".dotcontrol"
+                ],
+                "configuration": "./language-configuration.json"
             }
-        }]
+        ],
+        "grammars": [
+            {
+                "language": "dotvvm",
+                "scopeName": "text.html.dotvvm",
+                "path": "./syntaxes/dotvvm.tmLanguage.json",
+                "embeddedLanguages": {
+                    "text.html": "html"
+                }
+            }
+        ]
     },
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install"
     },
     "dependencies": {
-        "vscode-languageclient": "3.1.0-alpha.1",
-        "vscode-languageserver-types": "3.0.3",
-        "vscode-css-languageservice": "^2.1.0",
-        "vscode-html-languageservice": "^2.0.5",
-        "vscode-languageserver": "^3.1.0-alpha.1",
+        "vscode-css-languageservice": "^2.1.10",
+        "vscode-html-languageservice": "^2.0.10",
+        "vscode-languageclient": "^3.4.5",
+        "vscode-languageserver": "^3.4.3",
+        "vscode-languageserver-types": "^3.4.0",
         "vscode-nls": "^2.0.2",
-        "vscode-uri": "^1.0.0"
+        "vscode-uri": "^1.0.1",
+		"typescript": "^2.5.3"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "eslint": "^3.6.0",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "vscode": "^1.1.5",
+        "mocha": "^4.0.1",
+        "eslint": "^4.8.0",
+        "@types/node": "^8.0.33",
+        "@types/mocha": "^2.2.43"
     }
 }


### PR DESCRIPTION
This seems to get it running with the latest vscode without any errors in the output log. Without moving typescript into the vsix, you get missing module errors.