### PR TITLE
Better auto-completion of required control properties

### DIFF
--- a/src/dothtml-basic-ls/src/lib/dotnetUtils.ts
+++ b/src/dothtml-basic-ls/src/lib/dotnetUtils.ts
@@ -6,6 +6,7 @@ import { nullish } from "../utils"
 export type DotnetType = {
 	namespace: string
 	name: string
+	nongenericName?: string
 	assembly: string | null
 	fullName: string
 } & (
@@ -100,6 +101,7 @@ function parseSuffixes(type: DotnetType, rest: string): { type: DotnetType, rest
 			namespace,
 			assembly,
 			typeArgs,
+			nongenericName: name,
 			name: `${name}[${typeArgs.map(t => '[' + t.name + ']').join(',')}]`,
 			fullName: `${fullName}[${typeArgs.map(t => '[' + t.fullName + ']').join(',')}]`
 		}

--- a/src/dothtml-basic-ls/src/plugins/dotvvm/features/tagCompletion.ts
+++ b/src/dothtml-basic-ls/src/plugins/dotvvm/features/tagCompletion.ts
@@ -47,11 +47,16 @@ export class DotvvmTagCompletion
 		}
 
 		result += "="
-		if (prop.onlyBindings === true) {
-			if (prop.autocompleteBinding)
-				result += ("${" + counter.i++ + ":" + prop.autocompleteBinding + "}: ${" + counter.i++ + "}")
+		if (prop.onlyBindings === true || prop.autocompleteBinding) {
+			if (prop.autocompleteBinding && prop.bindingTypes?.length == 1)
+				result += ("{" + prop.autocompleteBinding + ": ${" + counter.i++ + "}}")
+
+			else if (prop.autocompleteBinding)
+				result += ("{${" + counter.i++ + ":" + prop.autocompleteBinding + "}: ${" + counter.i++ + "}}")
+
 			else 
 				result += "{$" + counter.i++ + "}"
+
 			return result + " "
 		}
 
@@ -93,13 +98,17 @@ export class DotvvmTagCompletion
 
 					const property = this.controlInformation.getPropertyCompletionInfo(p)
 					return DotvvmTagCompletion.createPropertySnippet(pName, property, counter)
-				}).join("") + "$" + counter.i++
+				}).join("")
+
+		const ending =
+			completeEndTag && info.selfClosing ? `$0 />` :
+			completeEndTag ? `>$0</${tag}>` : '$0'
 		
 		return {
 			label: tag,
 			documentation: description,
 			insertTextFormat: InsertTextFormat.Snippet,
-			insertText: tag + " " + requiredPropertiesSnippet + (completeEndTag ? `>$0</${tag}>` : '$0'),
+			insertText: tag + " " + requiredPropertiesSnippet + ending,
 			kind: control.kind == "code" ? CompletionItemKind.Class : CompletionItemKind.Module
 		}
 	}

--- a/src/dothtml-basic-ls/test/dotnetutils.test.ts
+++ b/src/dothtml-basic-ls/test/dotnetutils.test.ts
@@ -59,6 +59,7 @@ describe('dotnet utils', () => {
                 fullName: 'System.Nullable`1[[System.Boolean]]',
                 kind: 'generic',
                 name: 'Nullable`1[[Boolean]]',
+                nongenericName: "Nullable`1",
                 namespace: 'System',
                 typeArgs: [ {
                     assembly: 'CoreLibrary',
@@ -77,6 +78,7 @@ describe('dotnet utils', () => {
                 kind: 'generic',
                 name: 'Dictionary`2[[String],[String]]',
                 namespace: 'System.Collections.Generic',
+                nongenericName: "Dictionary`2",
                 typeArgs: [ {
                     assembly: 'CoreLibrary',
                     fullName: 'System.String',


### PR DESCRIPTION
For example, when you select dot:TextBox, it will insert this

![image](https://user-images.githubusercontent.com/7894687/188310509-9b326db4-ce08-4ec6-bced-76be092de25c.png)


When dot:Content, it inserts this

![image](https://user-images.githubusercontent.com/7894687/188310544-0b1a345b-aec6-45c4-981e-cacee9ac1039.png)


and so on