### PR TITLE
Config loader resilient to old config versions

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,16 +6,32 @@
 		{
 			"type": "npm",
 			"path": "src/dotvvm-vscode",
+			"script": "build",
+			"problemMatcher": "$ts-webpack",
+			// "isBackground": true,
+			// "presentation": {
+			// 	"reveal": "never",
+			// 	"group": "watchers"
+			// },
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"dependsOn": [ "LS-tsc-watch" ]
+		},
+		{
+			"type": "npm",
+			"path": "src/dothtml-basic-ls",
 			"script": "watch",
-			"problemMatcher": "$ts-webpack-watch",
+			"problemMatcher": "$tsc-watch",
 			"isBackground": true,
+			"label": "LS-tsc-watch",
 			"presentation": {
 				"reveal": "never",
 				"group": "watchers"
 			},
 			"group": {
-				"kind": "build",
-				"isDefault": true
+				"kind": "build"
 			},
 		},
 		{

--- a/src/dothtml-basic-ls/src/lib/dotvvmControlResolver.ts
+++ b/src/dothtml-basic-ls/src/lib/dotvvmControlResolver.ts
@@ -69,6 +69,19 @@ export function findControl(config: SerializedConfigSeeker, type: string | Dotne
 			}
 		}
 	}
+	// fallback for older dotvvm versions, only look for properties
+	for (const c of Object.values(config.configs)) {
+		if (c.properties && t.fullName in c.properties) {
+			return {
+				assembly: t.assembly ?? "unknown",
+				fullName: t.fullName,
+				name: t.name,
+				properties: c.properties?.[t.fullName] ?? emptyObject,
+				propGroups: c.propertyGroups?.[t.fullName] ?? emptyObject,
+				capabilities: c.capabilities?.[t.fullName] ?? emptyObject
+			}
+		}
+	}
 }
 
 export function resolveControl(config: SerializedConfigSeeker, name: string): ResolveControlResult | undefined {
@@ -118,7 +131,7 @@ export type ControlListResult = {
 }
 export function listAllControls(config: SerializedConfigSeeker): ControlListResult[] {
 	return config.cached("all-controls", c => {
-		const controlTypes = choose(unique(c.flatMap(c => Object.keys(c.controls ?? emptyObject))), parseTypeName)
+		const controlTypes = choose(unique(c.flatMap(c => Object.keys(c.controls ?? c.properties ?? emptyObject))), parseTypeName)
 		// console.log("Control types:", controlTypes)
 		const markupMapping = c.flatMap(c => c.config?.markup.controls ?? [])
 		const markupControls: ControlListResult[] =

--- a/src/dothtml-basic-ls/src/plugins/dotvvm/features/getHoverInfo.ts
+++ b/src/dothtml-basic-ls/src/plugins/dotvvm/features/getHoverInfo.ts
@@ -16,5 +16,6 @@ export function getHoverInfo(
     if (sublang.lang != "html") {
         return null;
     }
-    return { contents: "Some test hover" };
+    // return { contents: "Some test hover" };
+    return null
 }

--- a/src/dotvvm-vscode/package.json
+++ b/src/dotvvm-vscode/package.json
@@ -77,14 +77,14 @@
     "@vscode/test-electron": "^2.1.5",
     "eslint": "^8.20.0",
     "glob": "^8.0.3",
+    "js-yaml": "^4.1.0",
     "mocha": "^10.0.0",
     "ts-loader": "^9.3.1",
     "typescript": "^4.7.4",
     "vsce": "^2.11.0",
     "vscode-tmgrammar-test": "^0.1.1",
     "webpack": "^5.74.0",
-    "webpack-cli": "^4.10.0",
-    "js-yaml": "^4.1.0"
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "dothtml-basic-ls": "portal:../dothtml-basic-ls",


### PR DESCRIPTION
When started on DotVVM 3.x or 4.0, it should work somehow. With this patch it will

* use the default config, even if config is found, but it lacks "controls" field
* if "controls" field is missing, use "properties" to list all controls