### PR TITLE
Added support for Windows builds

### DIFF
--- a/src/build.ps1
+++ b/src/build.ps1
@@ -1,0 +1,21 @@
+cd tree-sitter-dotvvm
+echo "Building tree sitter"
+yarn install --immutable
+yarn build
+
+cd ..
+cd native-lib-dotvvm-spy
+echo "Attempting to build .NET Native dotvvm-spy"
+./build.ps1 -ErrorAction SilentlyContinue
+
+cd ..
+echo "Building dohtml language server"
+cd dothtml-basic-ls
+yarn install --immutable
+yarn build
+
+cd ..
+echo "Building dotvvm vscode"
+cd dotvvm-vscode
+yarn install --immutable
+yarn build

--- a/src/native-lib-dotvvm-spy/build.ps1
+++ b/src/native-lib-dotvvm-spy/build.ps1
@@ -1,0 +1,10 @@
+dotnet publish /p:NativeLib=Shared /p:SelfContained=true -r win-x64 -c Release
+Copy-Item -Force -Verbose ./bin/Release/net7.0/win-x64/native/* bin/
+
+cd node_binding
+Remove-Item -Recurse build
+
+yarn install
+yarn build
+yarn sanity-check
+cd ..

--- a/src/native-lib-dotvvm-spy/build.sh
+++ b/src/native-lib-dotvvm-spy/build.sh
@@ -19,6 +19,7 @@ clang -o bin/test_dyn test.c ./bin/libDotvvmSpy.so -g -Wall -pthread -lstdc++ -l
   # -g
 
 cd node_binding
+rm -rf build
 yarn install
 yarn build
 yarn sanity-check

--- a/src/native-lib-dotvvm-spy/node_binding/CMakeLists.txt
+++ b/src/native-lib-dotvvm-spy/node_binding/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.9)
-# set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
-
 project(dotnet-analyzer-lib-node)
 
 # Build a shared library named after the project from the .cc files
@@ -16,14 +14,38 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 # You should add this line in every CMake.js based project
 target_include_directories(${PROJECT_NAME} PRIVATE ${CMAKE_JS_INC})
 
+# Compile options 
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall) # -Wextra -Wpedantic -Werror)
 
+# Define our dependency (LibDotvvmSpy)
+add_library(LibDotvvmSpy SHARED IMPORTED)
+
+if (APPLE)
+  message(FATAL_ERROR "Apple platform is not supported" )
+endif(APPLE)
+
+if (WIN32)
+  message(STATUS "Configuring build for Windows")
+  set(LIBDOTVVMSPY_EXECUTABLE_NAME libDotvvmSpy.dll)
+  set_target_properties(LibDotvvmSpy PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../bin/${LIBDOTVVMSPY_EXECUTABLE_NAME}"
+    IMPORTED_IMPLIB "${CMAKE_SOURCE_DIR}/../bin/libDotvvmSpy.lib")
+endif(WIN32)
+
+if (UNIX)
+  message(STATUS "Configuring build for Linux")
+  set(LibDotvvmSpyExecutable libDotvvmSpy.so)
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/../bin/${LIBDOTVVMSPY_EXECUTABLE_NAME}"
+    BUILD_WITH_INSTALL_RPATH FALSE
+    LINK_FLAGS "-Wl,-rpath,\\\$ORIGIN")
+endif(UNIX)
+
 # link libDotvvmSpy.so
-set_target_properties(${PROJECT_NAME} PROPERTIES
-        BUILD_WITH_INSTALL_RPATH FALSE
-        LINK_FLAGS "-Wl,-rpath,\\\$ORIGIN")
-target_link_libraries(${PROJECT_NAME} ${CMAKE_SOURCE_DIR}/../bin/libDotvvmSpy.so)
-configure_file(${CMAKE_SOURCE_DIR}/../bin/libDotvvmSpy.so ${CMAKE_BINARY_DIR}/Release/libDotvvmSpy.so COPYONLY)
+target_link_libraries(${PROJECT_NAME} LibDotvvmSpy ${CMAKE_JS_LIB})
+configure_file(
+  ${CMAKE_SOURCE_DIR}/../bin/${LIBDOTVVMSPY_EXECUTABLE_NAME} 
+  ${CMAKE_BINARY_DIR}/Release/${LIBDOTVVMSPY_EXECUTABLE_NAME} COPYONLY)
 
 # include node-api header files
 add_definitions(-DNAPI_VERSION=3)
@@ -37,4 +59,3 @@ if(MSVC AND CMAKE_JS_NODELIB_DEF AND CMAKE_JS_NODELIB_TARGET)
   # Generate node.lib
   execute_process(COMMAND ${CMAKE_AR} /def:${CMAKE_JS_NODELIB_DEF} /out:${CMAKE_JS_NODELIB_TARGET} ${CMAKE_STATIC_LINKER_FLAGS})
 endif()
-

--- a/src/native-lib-dotvvm-spy/node_binding/package.json
+++ b/src/native-lib-dotvvm-spy/node_binding/package.json
@@ -11,7 +11,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "install": "cmake-js compile",
-    "build": "rm -rf build && cmake-js build",
+    "build": "cmake-js build",
     "sanity-check": "node test/sanitycheck.mjs"
   }
 }


### PR DESCRIPTION
I did not figure out how to make a package. However, build of the native libs seems to be working.

* dotvvm-vscode\dotvvm-extension-vscode\src\native-lib-dotvvm-spy\build.ps1
   * sanity check outputs my home directory
   * build generates the following stuff: 
![image](https://user-images.githubusercontent.com/12575176/203810498-3b4a7cdb-9ef1-4821-ab0d-8703ce0683b0.png)
* dotvvm-vscode\dotvvm-extension-vscode\src\build.ps1
   * All steps seem to finish without any errors