### PR TITLE
TM grammar: fix markup without directives + element property highlighting

### DIFF
--- a/src/dotvvm-vscode/src/test/grammar/HtmlWithoutDirectives.dothtml
+++ b/src/dotvvm-vscode/src/test/grammar/HtmlWithoutDirectives.dothtml
@@ -1,0 +1,7 @@
+# SYNTAX TEST "source.dotvvm" "html markup without directives in the start"
+<a href="abc" > def </a>
+#^ meta.scope.tag.a.dotvvm meta.tag.start.dotvvm
+#   ^^^^ meta.tag.start.dotvvm meta.attribute.href.dotvvm
+#         ^^^ meta.attribute.href.dotvvm string.quoted.dotvvm
+#               ^^^^^ meta.dotvvm.content
+#                      ^ meta.scope.tag.a.dotvvm meta.tag.end.dotvvm

--- a/src/dotvvm-vscode/syntax/dotvvm.tmLanguage.json
+++ b/src/dotvvm-vscode/syntax/dotvvm.tmLanguage.json
@@ -15,6 +15,9 @@
     "scope": {
       "patterns": [
         {
+          "include": "#comments"
+        },
+        {
           "include": "#directives"
         },
         {
@@ -23,7 +26,7 @@
       ]
     },
     "directives": {
-      "begin": "\\A",
+      "begin": "^(?=\\s*@)",
       "end": "^(?=\\s*[^@\\s])",
       "name": "meta.dotvvm.directives",
       "patterns": [
@@ -37,7 +40,7 @@
               "name": "keyword.control.dotvvm.directive.name meta.dotvvm.directives.directive.name"
             }
           },
-          "end": "\\n",
+          "end": "$",
           "name": "meta.dotvvm.directives.directive",
           "contentName": "meta.dotvvm.directives.directive.value"
         }
@@ -237,7 +240,7 @@
     "tags-name": {
       "patterns": [
         {
-          "match": "(\\w+)(:)(\\w[\\w0-9:-]*)",
+          "match": "(\\w+)(:)(\\w[\\w0-9:-_]*)",
           "captures": {
             "1": {
               "name": "keyword.control.dotvvm"
@@ -249,6 +252,10 @@
               "name": "entity.name.tag.dotvvm"
             }
           }
+        },
+        {
+          "match": "[A-Z][\\w0-9:-_.]*",
+          "name": "meta.tag.property.dotvvm entity.other.attribute-name.element-property"
         },
         {
           "match": "[a-z][\\w0-9:]*-[\\w0-9:-]*",

--- a/src/dotvvm-vscode/syntax/dotvvm.tmLanguage.yaml
+++ b/src/dotvvm-vscode/syntax/dotvvm.tmLanguage.yaml
@@ -11,11 +11,12 @@ patterns:
 repository:
   scope:
     patterns:
+    - include: '#comments'
     - include: '#directives'
     - include: '#content'
 
   directives:
-    begin: '\A'
+    begin: '^(?=\s*@)' # only start if there is something starting with @
     end: '^(?=\s*[^@\s])' # first non-empty row not starting with @
     name: meta.dotvvm.directives
     patterns:
@@ -23,7 +24,7 @@ repository:
       beginCaptures:
         1: { name: markup.bold.dotvvm.directive.at }
         2: { name: keyword.control.dotvvm.directive.name meta.dotvvm.directives.directive.name }
-      end: '\n'
+      end: '$'
       name: meta.dotvvm.directives.directive
       contentName: meta.dotvvm.directives.directive.value
 
@@ -145,11 +146,13 @@ repository:
   tags-name:
     patterns:
     # DotVVM (`<prefix>:<type>`) elements.
-    - match: '(\w+)(:)(\w[\w0-9:-]*)'
+    - match: '(\w+)(:)(\w[\w0-9:-_]*)'
       captures:
         1: { name: keyword.control.dotvvm }
         2: { name: punctuation.definition.keyword.dotvvm }
         3: { name: entity.name.tag.dotvvm }
+    # Properties, tags with uppercase first letter
+    - { match: '[A-Z][\w0-9:-_.]*', name: meta.tag.property.dotvvm entity.other.attribute-name.element-property }
     # Custom elements. (has a dash, but otherwise is a valid HTML element)
     - { match: '[a-z][\w0-9:]*-[\w0-9:-]*', name: meta.tag.custom.dotvvm entity.name.tag.dotvvm }
     # HTML elements.


### PR DESCRIPTION
Before (first line is "directive", element with uppercase letter is not matched):
![image](https://user-images.githubusercontent.com/7894687/206188886-769a8788-3ce4-471c-9730-dce1439744ff.png)

After
![image](https://user-images.githubusercontent.com/7894687/206189107-6e3a06eb-59e0-4aa6-bdb3-5abc18c34e57.png)

I gave the Postback.Handlers element the same color as attributes, since it's also a property.


I checked and tree-sitter grammar handles this well.